### PR TITLE
Refactor audio/recognizer modules and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ poetry run python main.py
 - Press **Ctrl+C twice** to safely terminate the application.
 - Resources will be properly released without freezing.
 
+## 🧪 Running Tests
+
+```bash
+poetry run python -m unittest discover -v
+```
+
+The tests use simple mocks and do not require audio devices or Vosk models.
+
 
 ## ⚙️ Planned Future Enhancements
 

--- a/audio.py
+++ b/audio.py
@@ -1,0 +1,23 @@
+import sys
+import threading
+import sounddevice as sd
+
+
+def audio_capture_worker(queue, stop_event, device_index=0, sample_rate=48000, chunk_size=4000):
+    """Capture audio from the monitor device and put chunks into a queue."""
+    def callback(indata, frames, time, status):
+        if status:
+            print(f"Audio Callback Status: {status}", file=sys.stderr)
+        queue.put(indata.copy())
+
+    stream = sd.InputStream(
+        device=device_index,
+        samplerate=sample_rate,
+        channels=1,
+        dtype="int16",
+        blocksize=chunk_size,
+        callback=callback,
+    )
+
+    with stream:
+        stop_event.wait()

--- a/main.py
+++ b/main.py
@@ -1,12 +1,12 @@
 from CaptionWindow import CaptionWindow
 from PyQt5 import QtWidgets, QtCore
 import sys
-import sounddevice as sd
 import queue
 import threading
 import signal
-from vosk import Model, KaldiRecognizer
-import json
+
+from audio import audio_capture_worker
+from recognizer import recognize_worker
 
 # --- 音声キャプチャ設定 ---
 SAMPLE_RATE = 48000
@@ -19,53 +19,6 @@ audio_queue = queue.Queue()
 # --- 停止フラグとCtrl+Cカウント ---
 stop_event = threading.Event()
 ctrl_c_count = 0
-
-def audio_capture_worker():
-    """sounddeviceでモニター音声をキャプチャ"""
-    def callback(indata, frames, time, status):
-        if status:
-            print(f"Audio Callback Status: {status}", file=sys.stderr)
-        audio_queue.put(indata.copy())
-
-    stream = sd.InputStream(
-        device=MONITOR_DEVICE_INDEX,
-        samplerate=SAMPLE_RATE,
-        channels=1,
-        dtype='int16',
-        blocksize=CHUNK_SIZE,
-        callback=callback,
-    )
-
-    with stream:
-        threading.Event().wait()
-
-def recognize_worker(window: CaptionWindow):
-    """Voskで音声認識してキャプション更新（Partial対応版）"""
-    model = Model(lang="en-us")  # or "ja" model for Japanese
-    rec = KaldiRecognizer(model, SAMPLE_RATE)
-
-    final_text = ""
-
-    while not stop_event.is_set():
-        try:
-            indata = audio_queue.get(timeout=0.1)  # timeout付きにして停止チェック
-        except queue.Empty:
-            continue
-        bytes_data = indata.tobytes()
-
-        if rec.AcceptWaveform(bytes_data):
-            result = rec.Result()
-            text = json.loads(result).get("text", "")
-            if text:
-                print(f"[FINAL] {text}")
-                final_text = text
-                window.update_caption(final_text)
-        else:
-            partial_result = rec.PartialResult()
-            partial_text = json.loads(partial_result).get("partial", "")
-            if partial_text:
-                print(f"[PARTIAL] {partial_text}")
-                window.update_caption(f"{final_text} {partial_text}")
 
 
 def handle_sigint(signum, frame):
@@ -92,10 +45,19 @@ if __name__ == "__main__":
     window = CaptionWindow()
 
     # 音声キャプチャ用スレッド
-    threading.Thread(target=audio_capture_worker, daemon=True).start()
+    threading.Thread(
+        target=audio_capture_worker,
+        args=(audio_queue, stop_event, MONITOR_DEVICE_INDEX, SAMPLE_RATE, CHUNK_SIZE),
+        daemon=True,
+    ).start()
 
     # 音声認識用スレッド
-    threading.Thread(target=recognize_worker, args=(window,), daemon=True).start()
+    threading.Thread(
+        target=recognize_worker,
+        args=(window, audio_queue, stop_event),
+        kwargs={"sample_rate": SAMPLE_RATE},
+        daemon=True,
+    ).start()
 
     timer = QtCore.QTimer()
     timer.timeout.connect(periodic_check)

--- a/recognizer.py
+++ b/recognizer.py
@@ -1,0 +1,45 @@
+import json
+import queue
+
+try:
+    from vosk import Model, KaldiRecognizer
+except Exception:  # pragma: no cover - dependency may be missing during tests
+    Model = None
+    KaldiRecognizer = None
+
+
+class SpeechRecognizer:
+    """Simple wrapper around Vosk recognizer"""
+    def __init__(self, lang="en-us", sample_rate=48000):
+        if Model is None or KaldiRecognizer is None:
+            raise ImportError("Vosk is required to use SpeechRecognizer")
+        self.model = Model(lang=lang)
+        self.rec = KaldiRecognizer(self.model, sample_rate)
+        self.final_text = ""
+
+    def process(self, indata, window):
+        bytes_data = indata.tobytes()
+        if self.rec.AcceptWaveform(bytes_data):
+            result = self.rec.Result()
+            text = json.loads(result).get("text", "")
+            if text:
+                self.final_text = text
+                window.update_caption(self.final_text)
+        else:
+            partial_result = self.rec.PartialResult()
+            partial_text = json.loads(partial_result).get("partial", "")
+            if partial_text:
+                window.update_caption(f"{self.final_text} {partial_text}")
+
+
+def recognize_worker(window, q: queue.Queue, stop_event, recognizer=None, lang="en-us", sample_rate=48000):
+    """Read audio chunks from the queue and update window captions."""
+    if recognizer is None:
+        recognizer = SpeechRecognizer(lang=lang, sample_rate=sample_rate)
+
+    while not stop_event.is_set():
+        try:
+            indata = q.get(timeout=0.1)
+        except queue.Empty:
+            continue
+        recognizer.process(indata, window)

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -1,0 +1,46 @@
+import queue
+import threading
+import time
+import unittest
+
+from recognizer import recognize_worker
+
+
+class DummyRecognizer:
+    def __init__(self):
+        self.processed = []
+
+    def process(self, indata, window):
+        self.processed.append(indata)
+        window.update_caption("dummy")
+
+
+class DummyWindow:
+    def __init__(self):
+        self.texts = []
+
+    def update_caption(self, text):
+        self.texts.append(text)
+
+
+class RecognizerWorkerTest(unittest.TestCase):
+    def test_worker_updates_caption(self):
+        q = queue.Queue()
+        stop = threading.Event()
+        dummy_rec = DummyRecognizer()
+        dummy_window = DummyWindow()
+
+        q.put(b"abc")
+
+        t = threading.Thread(target=recognize_worker, args=(dummy_window, q, stop, dummy_rec))
+        t.start()
+        time.sleep(0.2)
+        stop.set()
+        t.join()
+
+        self.assertEqual(dummy_window.texts[-1], "dummy")
+        self.assertTrue(dummy_rec.processed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor main logic into `audio.py` and `recognizer.py`
- update `main.py` to use the new modules
- add unit test for recognition worker
- document how to run tests

## Testing
- `python -m py_compile audio.py recognizer.py main.py CaptionWindow.py tests/test_recognizer.py`
- `python -m unittest discover -s tests -v`
