### PR TITLE
Add visibility check with logging

### DIFF
--- a/live_caption/CaptionWindow.py
+++ b/live_caption/CaptionWindow.py
@@ -1,6 +1,9 @@
 from PyQt5 import QtWidgets, QtCore
 import sys
 import textwrap
+import logging
+
+logger = logging.getLogger(__name__)
 
 class CaptionWindow(QtWidgets.QLabel):
     def __init__(self, mic_event=None):
@@ -125,6 +128,10 @@ class CaptionWindow(QtWidgets.QLabel):
         self.adjustSize()
         self.update_position()
         self.show()
+        if not self.isVisible():
+            error_msg = "Caption window failed to display"
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
 
         # 無音カウントダウンをリセット
         self.hide_timer.start()

--- a/live_caption/cli.py
+++ b/live_caption/cli.py
@@ -3,6 +3,7 @@ import signal
 import queue
 import threading
 import argparse
+import logging
 
 try:
     from PyQt5 import QtWidgets, QtCore
@@ -14,6 +15,19 @@ except Exception:  # pragma: no cover - optional for tests
 
 from .audio import audio_capture_worker, microphone_capture_worker
 from .recognizer import recognize_worker
+
+logger = logging.getLogger(__name__)
+
+
+def setup_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.FileHandler("live_caption.log"),
+            logging.StreamHandler(),
+        ],
+    )
 
 # --- 音声キャプチャ設定 ---
 SAMPLE_RATE = 48000
@@ -52,6 +66,8 @@ def run_app(device_index=MONITOR_DEVICE_INDEX, sample_rate=SAMPLE_RATE, chunk_si
     """Start the caption application."""
     if QtWidgets is None or QtCore is None or CaptionWindow is None:
         raise ImportError("PyQt5 is required to run the application")
+    setup_logging()
+    logger.info("Starting Live Caption application")
     signal.signal(signal.SIGINT, handle_sigint)
 
     app = QtWidgets.QApplication(sys.argv)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,3 @@
+import sys
+from live_caption import cli as _cli
+sys.modules[__name__] = _cli


### PR DESCRIPTION
## Summary
- add a tiny `main.py` proxy for tests
- log application startup
- report an error when caption window is not visible

## Testing
- `python -m unittest discover -v tests`